### PR TITLE
Add more debugging

### DIFF
--- a/src/heatmapUtils.ts
+++ b/src/heatmapUtils.ts
@@ -37,15 +37,12 @@ export function createSmartInterpolatedHeatmap(dataset: FootTrafficWithTimeSerie
     maxValue,
     p,
     framebufferFactor,
+    debug: true,
     valueToColor: `
       vec3 valueToColor(float value) {
-        if (value < 0.3) {
-          return vec3(0.0, 0.0, 1.0 - value);
-        } else if (value < 0.7) {
-          return vec3(value * 2.0 - 0.6, 1.0, 0.0);
-        } else {
-          return vec3(1.0, 1.0 - value, 0.0);
-        }
+        if (value < 0.3) return vec3(0.0, 0.0, 1.0 - value);
+        if (value < 0.7) return vec3(value * 2.0 - 0.6, 1.0, 0.0);
+        return vec3(1.0, 1.0 - value, 0.0);
       }
     `,
   })


### PR DESCRIPTION
## Summary
- add deep debug option for heatmap layer
- output framebuffer and WebGL errors via new helpers
- tweak smart heatmap util to enable debugging by default

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6878175f8710832a955241f1fc4ca07f